### PR TITLE
Fix string parsing in query setup when predicting

### DIFF
--- a/landshark/tfread.py
+++ b/landshark/tfread.py
@@ -74,7 +74,7 @@ def setup_query(config: str,
                 querydir: str,
                 checkpoint: str
                 ) -> Tuple[Training, FeatureSet, List[str], int, int, str]:
-    strip_list = querydir.split("strip")[-1].split("of")
+    strip_list = querydir.rstrip("/").split("strip")[-1].split("of")
     assert len(strip_list) == 2
     strip = int(strip_list[0])
     nstrip = int(strip_list[1])


### PR DESCRIPTION
`setup_query()` does not handle trailing slashes on the query directory, as you would get if using tab completion to compose arguments to the `landshark predict` CLI. This PR fixes this by stripping trailing slashes before parsing the query directory string.